### PR TITLE
Lint && reload iptables service

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,11 @@
+---
+
+extends: default
+
+rules:
+  line-length: disable
+  truthy:
+    allowed-values: ['yes', 'no']
+    level: error
+
+...

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+
+- name: reload iptables
+  service:
+    name: iptables
+    state: reloaded
+
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,14 +28,7 @@
   template:
     src: '{{ iptables_template }}'
     dest: /etc/sysconfig/iptables
-  register: iptablesdeploy
+  notify: reload iptables
   when: ansible_os_family == "RedHat"
 
-- name: restart iptables
-  service:
-    name: iptables
-    state: restarted
-  when: iptablesdeploy.changed
-
 ...
-


### PR DESCRIPTION
- makes role yamllint and ansible-lint compatible
- reload iptables instead of restarting it
  - all old connections wont be dropped
  - dont need a short downtime for changes